### PR TITLE
fixed minor f-string issue

### DIFF
--- a/crawler-artofproblemsolving.com.py
+++ b/crawler-artofproblemsolving.com.py
@@ -183,7 +183,7 @@ def crawl_topic_page(sub_url, category_id, topic_id, c, extra_opt):
         # compose title
         topic_txt = title
         if post_number != "1":
-            topic_txt += " (posts after #{post_number})"
+            topic_txt += f" (posts after #{post_number})"
         topic_txt += "\n\n"
         # get posts
         for post in posts_data:


### PR DESCRIPTION
Small fix of issue introduced when switching to f-strings in https://github.com/approach0/a0-crawlers/commit/f5cc13df0ea5cadcd35a108cde307ee8906835e9. It caused AoPS results to look like "(posts after #{post_number})" without the actual value substituted.